### PR TITLE
Change JsonResponseDecoder priority to be before a default priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- There should always be "Unreleased" section at the beginning. -->
 
 ## Unreleased
+- Change a priority for `JsonResponseDecoder` to 60 (_from 10_) to be **before** a default priority (_50_) 
 
 ## 1.0.0 - 2021-05-13
 - Initial implementation

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ See [Solr extension readme](https://github.com/lmc-eu/cqrs-solr#query-builder) f
 | ---     | ---   | --- | ---      | ---     |
 | Lmc\Cqrs\Http\Decoder\HttpMessageResponseDecoder | `@lmc_cqrs.response_decoder.http` | `lmc_cqrs.response_decoder` | 90 | if `http` extension is enabled |
 | Lmc\Cqrs\Http\Decoder\StreamResponseDecoder | `@lmc_cqrs.response_decoder.stream` | `lmc_cqrs.response_decoder` | 70 | if `http` extension is enabled |
-| Lmc\Cqrs\Types\Decoder\JsonResponseDecoder | `@lmc_cqrs.response_decoder.json` | `lmc_cqrs.response_decoder` | 20 | *always* |
+| Lmc\Cqrs\Types\Decoder\JsonResponseDecoder | `@lmc_cqrs.response_decoder.json` | `lmc_cqrs.response_decoder` | 60 | *always* |
 
 ### Profiler formatters
 | Service | Alias | Tag | Priority | Enabled |

--- a/src/Resources/config/services-handler.yaml
+++ b/src/Resources/config/services-handler.yaml
@@ -51,6 +51,6 @@ services:
     lmc_cqrs.response_decoder.json:
         class: Lmc\Cqrs\Types\Decoder\JsonResponseDecoder
         tags:
-            - { name: lmc_cqrs.response_decoder, priority: 20 }
+            - { name: lmc_cqrs.response_decoder, priority: 60 }
 
     Lmc\Cqrs\Types\Decoder\JsonResponseDecoder: '@lmc_cqrs.response_decoder.json'

--- a/tests/DependencyInjection/LmcCqrsExtensionTest.php
+++ b/tests/DependencyInjection/LmcCqrsExtensionTest.php
@@ -93,7 +93,7 @@ class LmcCqrsExtensionTest extends AbstractTestCase
             'lmc_cqrs.response_decoder.json',
             JsonResponseDecoder::class,
             'lmc_cqrs.response_decoder',
-            20,
+            60,
             $containerBuilder
         );
 


### PR DESCRIPTION
This change will enhance a DX from using this decoder, since if you want to take advantage of this decoder, you have to explicitly set a priority of your decoder to <20. Now it will only require to "register" your decoder to use it.